### PR TITLE
Added UnitValue declaration

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -82,6 +82,7 @@ const copyDistFiles = targetDir => {
     fs.copySync('extendscript/es.dollar.d.ts', `${targetDir}/es.dollar.d.ts`)
     fs.copySync('extendscript/es.file.d.ts', `${targetDir}/es.file.d.ts`)
     fs.copySync('extendscript/es.global.d.ts', `${targetDir}/es.global.d.ts`)
+    fs.copySync('extendscript/es.unitvalue.d.ts', `${targetDir}/es.unitvalue.d.ts`)
 }
 
 const mkDistDir = (targetDir) => {

--- a/dist/cc/es.d.ts
+++ b/dist/cc/es.d.ts
@@ -1,3 +1,4 @@
 /// <reference path="./es.global.d.ts" />
 /// <reference path="./es.dollar.d.ts" />
 /// <reference path="./es.file.d.ts" />
+/// <reference path="./es.unitvalue.d.ts" />

--- a/dist/cc/es.unitvalue.d.ts
+++ b/dist/cc/es.unitvalue.d.ts
@@ -1,0 +1,80 @@
+/**
+* Represents measurement values that contain both the numeric magnitude and 
+* the unit of measurement. 
+*/
+interface UnitValue {
+	/**
+     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * use as a base for percentage values. This is used as the base conversion 
+	 * unit for pixels and percentages; see Converting pixel and percentage values.
+	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
+	 * pixels at 72 dpi. Set to null to restore the default.
+     */
+	baseUnit: UnitValue | null;
+
+	/**
+	 * The unit type in abbreviated form; for example, "cm" or "in".
+	 */
+	type: ScaleUnit;
+
+	/**
+	 * The numeric measurement value.
+	 */
+	value: number | string;
+
+	/**
+	 * Returns the numeric value of this object in the given unit. If the unit is 
+	 * unknown or cannot be computed, generates a run-time error.
+	 */
+	as(unit: ScaleUnit): number;
+
+	/**
+	 * Converts this object to the given unit, resetting the type and value accordingly.
+	 * Returns true if the conversion is successful. If the unit is unknown or the 
+	 * object cannot be converted, generates a run-time error and returns false.
+	 */
+	convert(unit: ScaleUnit): boolean;
+}
+
+declare const UnitValue: {
+	/**
+     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * use as a base for percentage values. This is used as the base conversion 
+	 * unit for pixels and percentages; see Converting pixel and percentage values.
+	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
+	 * pixels at 72 dpi. Set to null to restore the default.
+     */
+	baseUnit: UnitValue | null;
+	
+	/**
+     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * of measurement.The UnitValue constructor creates a new UnitValue object.
+     */
+	new (value: number | string, unit?: ScaleUnit): UnitValue & number
+	
+	/**
+     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * of measurement.The UnitValue constructor creates a new UnitValue object. 
+	 * The keyword new is optional.
+     */
+	(value: number | string, unit?: ScaleUnit): UnitValue & number
+}
+
+/**
+ * The unit is specified with a string in abbreviated, singular, or plural form.
+ */
+type ScaleUnit =  "in" | "inch" | "inches"
+				| "ft" | "foot" | "feet"
+				| "yd" | "yard" | "yards"
+				| "mi" | "mile" | "miles"
+				| "mm" | "millimeter" | "millimeters"
+				| "cm" | "centimeter" | "centimeters"
+				| "m" | "meter" | "meters"
+				| "km" | "kilometer" | "kilometers"
+				| "pt" | "point" | "points"
+				| "pc" | "pica" | "picas"
+				| "tpt" | "traditional point" | "traditional points"
+				| "tpc" | "traditional pica" | "traditional picas"
+				| "ci" | "cicero" | "ciceros"
+				| "px" | "pixel" | "pixels"
+				| "%" | "percent" | "percent"

--- a/dist/cs6/es.d.ts
+++ b/dist/cs6/es.d.ts
@@ -1,3 +1,4 @@
 /// <reference path="./es.global.d.ts" />
 /// <reference path="./es.dollar.d.ts" />
 /// <reference path="./es.file.d.ts" />
+/// <reference path="./es.unitvalue.d.ts" />

--- a/dist/cs6/es.unitvalue.d.ts
+++ b/dist/cs6/es.unitvalue.d.ts
@@ -1,0 +1,80 @@
+/**
+* Represents measurement values that contain both the numeric magnitude and 
+* the unit of measurement. 
+*/
+interface UnitValue {
+	/**
+     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * use as a base for percentage values. This is used as the base conversion 
+	 * unit for pixels and percentages; see Converting pixel and percentage values.
+	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
+	 * pixels at 72 dpi. Set to null to restore the default.
+     */
+	baseUnit: UnitValue | null;
+
+	/**
+	 * The unit type in abbreviated form; for example, "cm" or "in".
+	 */
+	type: ScaleUnit;
+
+	/**
+	 * The numeric measurement value.
+	 */
+	value: number | string;
+
+	/**
+	 * Returns the numeric value of this object in the given unit. If the unit is 
+	 * unknown or cannot be computed, generates a run-time error.
+	 */
+	as(unit: ScaleUnit): number;
+
+	/**
+	 * Converts this object to the given unit, resetting the type and value accordingly.
+	 * Returns true if the conversion is successful. If the unit is unknown or the 
+	 * object cannot be converted, generates a run-time error and returns false.
+	 */
+	convert(unit: ScaleUnit): boolean;
+}
+
+declare const UnitValue: {
+	/**
+     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * use as a base for percentage values. This is used as the base conversion 
+	 * unit for pixels and percentages; see Converting pixel and percentage values.
+	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
+	 * pixels at 72 dpi. Set to null to restore the default.
+     */
+	baseUnit: UnitValue | null;
+	
+	/**
+     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * of measurement.The UnitValue constructor creates a new UnitValue object.
+     */
+	new (value: number | string, unit?: ScaleUnit): UnitValue & number
+	
+	/**
+     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * of measurement.The UnitValue constructor creates a new UnitValue object. 
+	 * The keyword new is optional.
+     */
+	(value: number | string, unit?: ScaleUnit): UnitValue & number
+}
+
+/**
+ * The unit is specified with a string in abbreviated, singular, or plural form.
+ */
+type ScaleUnit =  "in" | "inch" | "inches"
+				| "ft" | "foot" | "feet"
+				| "yd" | "yard" | "yards"
+				| "mi" | "mile" | "miles"
+				| "mm" | "millimeter" | "millimeters"
+				| "cm" | "centimeter" | "centimeters"
+				| "m" | "meter" | "meters"
+				| "km" | "kilometer" | "kilometers"
+				| "pt" | "point" | "points"
+				| "pc" | "pica" | "picas"
+				| "tpt" | "traditional point" | "traditional points"
+				| "tpc" | "traditional pica" | "traditional picas"
+				| "ci" | "cicero" | "ciceros"
+				| "px" | "pixel" | "pixels"
+				| "%" | "percent" | "percent"

--- a/extendscript/es.d.ts
+++ b/extendscript/es.d.ts
@@ -1,3 +1,4 @@
 /// <reference path="./es.global.d.ts" />
 /// <reference path="./es.dollar.d.ts" />
 /// <reference path="./es.file.d.ts" />
+/// <reference path="./es.unitvalue.d.ts" />

--- a/extendscript/es.unitvalue.d.ts
+++ b/extendscript/es.unitvalue.d.ts
@@ -1,0 +1,80 @@
+/**
+* Represents measurement values that contain both the numeric magnitude and 
+* the unit of measurement. 
+*/
+interface UnitValue {
+	/**
+     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * use as a base for percentage values. This is used as the base conversion 
+	 * unit for pixels and percentages; see Converting pixel and percentage values.
+	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
+	 * pixels at 72 dpi. Set to null to restore the default.
+     */
+	baseUnit: UnitValue | null;
+
+	/**
+	 * The unit type in abbreviated form; for example, "cm" or "in".
+	 */
+	type: ScaleUnit;
+
+	/**
+	 * The numeric measurement value.
+	 */
+	value: number | string;
+
+	/**
+	 * Returns the numeric value of this object in the given unit. If the unit is 
+	 * unknown or cannot be computed, generates a run-time error.
+	 */
+	as(unit: ScaleUnit): number;
+
+	/**
+	 * Converts this object to the given unit, resetting the type and value accordingly.
+	 * Returns true if the conversion is successful. If the unit is unknown or the 
+	 * object cannot be converted, generates a run-time error and returns false.
+	 */
+	convert(unit: ScaleUnit): boolean;
+}
+
+declare const UnitValue: {
+	/**
+     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * use as a base for percentage values. This is used as the base conversion 
+	 * unit for pixels and percentages; see Converting pixel and percentage values.
+	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
+	 * pixels at 72 dpi. Set to null to restore the default.
+     */
+	baseUnit: UnitValue | null;
+	
+	/**
+     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * of measurement.The UnitValue constructor creates a new UnitValue object.
+     */
+	new (value: number | string, unit?: ScaleUnit): UnitValue & number
+	
+	/**
+     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * of measurement.The UnitValue constructor creates a new UnitValue object. 
+	 * The keyword new is optional.
+     */
+	(value: number | string, unit?: ScaleUnit): UnitValue & number
+}
+
+/**
+ * The unit is specified with a string in abbreviated, singular, or plural form.
+ */
+type ScaleUnit =  "in" | "inch" | "inches"
+				| "ft" | "foot" | "feet"
+				| "yd" | "yard" | "yards"
+				| "mi" | "mile" | "miles"
+				| "mm" | "millimeter" | "millimeters"
+				| "cm" | "centimeter" | "centimeters"
+				| "m" | "meter" | "meters"
+				| "km" | "kilometer" | "kilometers"
+				| "pt" | "point" | "points"
+				| "pc" | "pica" | "picas"
+				| "tpt" | "traditional point" | "traditional points"
+				| "tpc" | "traditional pica" | "traditional picas"
+				| "ci" | "cicero" | "ciceros"
+				| "px" | "pixel" | "pixels"
+				| "%" | "percent" | "percent"


### PR DESCRIPTION
ExtendScripts UnitValue can be used as callable, constructable or global var. It returns an intersection type of UnitValue and number. Tested the declaration with examples from the Adobe Tools Guide CC (incl. computing with unit values) and it works fine.

Reference: http://download.macromedia.com/pub/developer/aftereffects/scripting/JavaScript-Tools-Guide-CC.pdf
(same specs for CS6)