### PR TITLE
Separate class declarations from interfaces

### DIFF
--- a/assets/cc/chapter-2.txt
+++ b/assets/cc/chapter-2.txt
@@ -511,7 +511,7 @@ significant. For example, en_US, en_UK, ja_JP, de_DE,
 fr_FR.
 macintoshFileTypes array of string Read-only. A list of file image types Adobe
 Photoshop CC can open.
-measurementLog MeasurementLog The log of measurements taken.
+measurementLog MeasurementLog Read-only. The log of measurements taken.
 name string Read-only. The application's name.
 notifiers Notifiers Read-only. The collection of notifiers currently
 configured (in the Scripts Events Manager menu in
@@ -3376,7 +3376,7 @@ or right direction points determines the arc of the curve. You use the left dire
 concave.
 Properties
 Property Value type What it is
-anchor array of number Read-only. The X and Y coordinates of the anchor point of the
+anchor array of array of number Read-only. The X and Y coordinates of the anchor point of the
 curve.
 kind PointKind Read-only. The role (corner or smooth) this point plays in the
 containing path segment.
@@ -3406,7 +3406,7 @@ or right direction points determines the arc of the curve. You use the left dire
 concave.
 Properties
 Property Value type What it is
-anchor array of number Read-write. The X and Y coordinates of the anchor point of
+anchor array of array of number Read-write. The X and Y coordinates of the anchor point of
 the curve.
 kind PointKind Read-write. The role (corner or smooth) this point plays in the
 containing path segment.
@@ -4008,7 +4008,7 @@ select
 [, type]
 [, feather]
 [, antiAlias])
-array of number
+array of array of number
 SelectionType
 number
 boolean

--- a/assets/classification.txt
+++ b/assets/classification.txt
@@ -1,0 +1,108 @@
+//
+// Classification of declaration types 
+//
+
+/**
+ * DOM objects with a "parent" property, without constructor.
+ */
+ArtLayer
+ArtLayers
+Channel
+Channels
+ColorSampler
+ColorSamplers
+CountItem
+CountItems
+Document
+DocumentInfo
+Documents
+Guide
+Guides
+HistoryState
+HistoryStates
+LayerComp
+LayerComps
+Layers
+LayerSet
+LayerSets
+Notifier
+Notifiers
+PathItem
+PathItems
+PathPoint
+PathPoints
+Preferences
+Selection
+SubPathItem
+SubPathItems
+TextFont
+TextFonts
+TextItem
+TextItems
+xmpMetadata
+
+/**
+ * DOM objects without "parent" property, without constructor.
+ * "Application" is the root of the DOM.
+ */
+Application
+MeasurementLog
+MeasurementScale
+
+/**
+ * Classes with explicit parameters in the constructor.
+ */
+File
+Folder
+UnitValue
+
+/**
+ * Classes with parameterless constructors. 
+ */
+ActionDescriptor
+ActionList
+ActionReference
+BatchOptions
+BitmapConversionOptions
+BMPSaveOptions
+CameraRAWOpenOptions
+CMYKColor
+ContactSheetOptions
+DCS1_SaveOptions
+DCS2_SaveOptions
+DICOMOpenOptions
+EPSOpenOptions
+EPSSaveOptions
+ExportOptionsIllustrator
+ExportOptionsSaveForWeb
+GalleryBannerOptions
+GalleryCustomColorOptions
+GalleryImagesOptions
+GallerySecurityOptions
+GalleryThumbnailOptions
+GIFSaveOptions
+GrayColor
+HSBColor
+IndexedConversionOptions
+JPEGSaveOptions
+LabColor
+NoColor
+PathPointInfo
+PDFOpenOptions
+PDFSaveOptions
+PhotoCDOpenOptions
+PhotoshopSaveOptions
+PICTFileSaveOptions
+PICTResourceSaveOptions
+PicturePackageOptions
+PixarSaveOptions
+PNGSaveOptions
+PresentationOptions
+RawFormatOpenOptions
+RawSaveOptions
+RGBColor
+SGIRGBSaveOptions
+SolidColor
+SubPathInfo
+TargaSaveOptions
+TiffSaveOptions

--- a/assets/cs6/chapter-2.txt
+++ b/assets/cs6/chapter-2.txt
@@ -520,7 +520,7 @@ significant. For example, en_US, en_UK, ja_JP, de_DE,
 fr_FR.
 macintoshFileTypes array of string Read-only. A list of file image types Adobe
 Photoshop CS6 can open.
-measurementLog MeasurementLog The log of measurements taken.
+measurementLog MeasurementLog Read-only. The log of measurements taken.
 name string Read-only. The application's name.
 notifiers Notifiers Read-only. The collection of notifiers currently
 configured (in the Scripts Events Manager menu in
@@ -3485,7 +3485,7 @@ or right direction points determines the arc of the curve. You use the left dire
 concave.
 Properties
 Property Value type What it is
-anchor array of number Read-only. The X and Y coordinates of the anchor point of the
+anchor array of array of number Read-only. The X and Y coordinates of the anchor point of the
 curve.
 kind PointKind Read-only. The role (corner or smooth) this point plays in the
 containing path segment.
@@ -3528,7 +3528,7 @@ stopPoint.leftDirection = stop;
 stopPoint.rightDirection = stop;
 stopPoint.kind = PointKind.CORNERPOINT;
 Property Value type What it is
-anchor array of number Read-write. The X and Y coordinates of the anchor point of
+anchor array of array of number Read-write. The X and Y coordinates of the anchor point of
 the curve.
 kind PointKind Read-write. The role (corner or smooth) this point plays in the
 containing path segment.
@@ -4154,7 +4154,7 @@ select
 [, type]
 [, feather]
 [, antiAlias])
-array of number
+array of array of number
 SelectionType
 number
 boolean

--- a/dist/cc/es.unitvalue.d.ts
+++ b/dist/cc/es.unitvalue.d.ts
@@ -4,12 +4,12 @@
 */
 interface UnitValue {
 	/**
-     * A UnitValue object that defines the size of one pixel, or a total size to 
+	* A UnitValue object that defines the size of one pixel, or a total size to 
 	 * use as a base for percentage values. This is used as the base conversion 
 	 * unit for pixels and percentages; see Converting pixel and percentage values.
 	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
 	 * pixels at 72 dpi. Set to null to restore the default.
-     */
+	 */
 	baseUnit: UnitValue | null;
 
 	/**
@@ -38,43 +38,43 @@ interface UnitValue {
 
 declare const UnitValue: {
 	/**
-     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * A UnitValue object that defines the size of one pixel, or a total size to 
 	 * use as a base for percentage values. This is used as the base conversion 
 	 * unit for pixels and percentages; see Converting pixel and percentage values.
 	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
 	 * pixels at 72 dpi. Set to null to restore the default.
-     */
+	 */
 	baseUnit: UnitValue | null;
 	
 	/**
-     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * Represents measurement values that contain both the numeric magnitude and the unit 
 	 * of measurement.The UnitValue constructor creates a new UnitValue object.
-     */
+	 */
 	new (value: number | string, unit?: ScaleUnit): UnitValue & number
 	
 	/**
-     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * Represents measurement values that contain both the numeric magnitude and the unit 
 	 * of measurement.The UnitValue constructor creates a new UnitValue object. 
 	 * The keyword new is optional.
-     */
+	 */
 	(value: number | string, unit?: ScaleUnit): UnitValue & number
 }
 
 /**
  * The unit is specified with a string in abbreviated, singular, or plural form.
  */
-type ScaleUnit =  "in" | "inch" | "inches"
-				| "ft" | "foot" | "feet"
-				| "yd" | "yard" | "yards"
-				| "mi" | "mile" | "miles"
-				| "mm" | "millimeter" | "millimeters"
-				| "cm" | "centimeter" | "centimeters"
-				| "m" | "meter" | "meters"
-				| "km" | "kilometer" | "kilometers"
-				| "pt" | "point" | "points"
-				| "pc" | "pica" | "picas"
-				| "tpt" | "traditional point" | "traditional points"
-				| "tpc" | "traditional pica" | "traditional picas"
-				| "ci" | "cicero" | "ciceros"
-				| "px" | "pixel" | "pixels"
-				| "%" | "percent" | "percent"
+type ScaleUnit = "in" | "inch" | "inches"
+		| "ft" | "foot" | "feet"
+		| "yd" | "yard" | "yards"
+		| "mi" | "mile" | "miles"
+		| "mm" | "millimeter" | "millimeters"
+		| "cm" | "centimeter" | "centimeters"
+		| "m" | "meter" | "meters"
+		| "km" | "kilometer" | "kilometers"
+		| "pt" | "point" | "points"
+		| "pc" | "pica" | "picas"
+		| "tpt" | "traditional point" | "traditional points"
+		| "tpc" | "traditional pica" | "traditional picas"
+		| "ci" | "cicero" | "ciceros"
+		| "px" | "pixel" | "pixels"
+		| "%" | "percent" | "percent"

--- a/dist/cc/ps.types.d.ts
+++ b/dist/cc/ps.types.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference path="ps.constants.d.ts" />
 
-interface ActionDescriptor {
+declare class ActionDescriptor {
     /**
      * The number of keys contained in the descriptor.
      */
@@ -205,7 +205,7 @@ interface ActionDescriptor {
 
 }
 
-interface ActionList {
+declare class ActionList {
     /**
      * The number of commands that comprise the action.
      */
@@ -373,7 +373,7 @@ interface ActionList {
 
 }
 
-interface ActionReference {
+declare class ActionReference {
     /**
      * The class name of the referenced Action object.
      */
@@ -1365,7 +1365,7 @@ interface ArtLayers {
 
 }
 
-interface BatchOptions {
+declare class BatchOptions {
     /**
      * The type of destination for the processed files (default:
      * BatchDestinationType.NODESTINATION).
@@ -1443,7 +1443,7 @@ interface BatchOptions {
 
 }
 
-interface BitmapConversionOptions {
+declare class BitmapConversionOptions {
     /**
      * The angle (in degrees) at which to orient individual dots. See shape.
      * Valid only when method = BitmapConversionType.HALFTONESCREEN.
@@ -1489,7 +1489,7 @@ interface BitmapConversionOptions {
 
 }
 
-interface BMPSaveOptions {
+declare class BMPSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -1524,7 +1524,7 @@ interface BMPSaveOptions {
 
 }
 
-interface CameraRAWOpenOptions {
+declare class CameraRAWOpenOptions {
     /**
      * The number of bits per channel.
      */
@@ -1731,7 +1731,7 @@ interface Channel {
 
 }
 
-interface Channels {
+declare class Channels {
     /**
      * Creates a new channel object and adds it to this collection.
      */
@@ -1749,7 +1749,7 @@ interface Channels {
 
 }
 
-interface CMYKColor {
+declare class CMYKColor {
     /**
      * The black color value (as percent).
      */
@@ -1843,7 +1843,7 @@ interface ColorSamplers {
 
 }
 
-interface ContactSheetOptions {
+declare class ContactSheetOptions {
     /**
      * True to place the images horizontally (left to right, then top to
      * bottom) first (default: true).
@@ -1986,7 +1986,7 @@ interface CountItems {
 
 }
 
-interface DCS1_SaveOptions {
+declare class DCS1_SaveOptions {
     /**
      * (default: DCSType.COLORCOMPOSITE).
      */
@@ -2036,7 +2036,7 @@ interface DCS1_SaveOptions {
 
 }
 
-interface DCS2_SaveOptions {
+declare class DCS2_SaveOptions {
     /**
      * The type of composite file to create (default: DCSType.NOCOMPOSITE).
      */
@@ -2097,7 +2097,7 @@ interface DCS2_SaveOptions {
 
 }
 
-interface DICOMOpenOptions {
+declare class DICOMOpenOptions {
     /**
      * True to make the patient information anonymous.
      */
@@ -2505,7 +2505,7 @@ interface Document {
 
 }
 
-interface DocumentPrintSettings {
+declare class DocumentPrintSettings {
     /**
      * Background color of page.
      */
@@ -2797,7 +2797,7 @@ interface Documents {
 
 }
 
-interface EPSOpenOptions {
+declare class EPSOpenOptions {
     /**
      * True to use antialias.
      */
@@ -2835,7 +2835,7 @@ interface EPSOpenOptions {
 
 }
 
-interface EPSSaveOptions {
+declare class EPSSaveOptions {
     /**
      * True to embed the color profile in this document.
      */
@@ -2891,7 +2891,7 @@ interface EPSSaveOptions {
 
 }
 
-interface ExportOptionsIllustrator {
+declare class ExportOptionsIllustrator {
     /**
      * The type of path to export (default: IllustratorPathType.DOCUMENTBOUNDS).
      */
@@ -2910,7 +2910,7 @@ interface ExportOptionsIllustrator {
 
 }
 
-interface ExportOptionsSaveForWeb {
+declare class ExportOptionsSaveForWeb {
     /**
      * Applies blur to the image to reduce artifacts (default: 0.0).
      */
@@ -3016,7 +3016,7 @@ interface ExportOptionsSaveForWeb {
 
 }
 
-interface GalleryBannerOptions {
+declare class GalleryBannerOptions {
     /**
      * The web photo gallery contact info.
      */
@@ -3054,7 +3054,7 @@ interface GalleryBannerOptions {
 
 }
 
-interface GalleryCustomColorOptions {
+declare class GalleryCustomColorOptions {
     /**
      * The color to use to indicate an active link.
      */
@@ -3092,7 +3092,7 @@ interface GalleryCustomColorOptions {
 
 }
 
-interface GalleryImagesOptions {
+declare class GalleryImagesOptions {
     /**
      * The size (in pixels) of the border that separates images (default: 0).
      */
@@ -3173,7 +3173,7 @@ interface GalleryImagesOptions {
 
 }
 
-interface GalleryOptions {
+declare class GalleryOptions {
     /**
      * True to add width and height attributes for images (default: true).
      */
@@ -3244,7 +3244,7 @@ interface GalleryOptions {
 
 }
 
-interface GallerySecurityOptions {
+declare class GallerySecurityOptions {
     /**
      * The web photo gallery security content (default:
      * GallerySecurityType.NONE).
@@ -3295,7 +3295,7 @@ interface GallerySecurityOptions {
 
 }
 
-interface GalleryThumbnailOptions {
+declare class GalleryThumbnailOptions {
     /**
      * The amount of border pixels you want around your thumbnail images
      * (default: 0).
@@ -3364,7 +3364,7 @@ interface GalleryThumbnailOptions {
 
 }
 
-interface GIFSaveOptions {
+declare class GIFSaveOptions {
     /**
      * The number of palette colors. Valid only when palette =
      * Palette.LOCALADAPTIVE, LOCALPERCEPTUAL, LOCALSELECTIVE, MACOSPALETTE,
@@ -3424,7 +3424,7 @@ interface GIFSaveOptions {
 
 }
 
-interface GrayColor {
+declare class GrayColor {
     /**
      * The gray value (default: 0.0).
      */
@@ -3437,7 +3437,7 @@ interface GrayColor {
 
 }
 
-interface Guide {
+declare class Guide {
     /**
      * Indicates whether the guide is vertical or horizontal.
      */
@@ -3525,7 +3525,7 @@ interface HistoryStates {
 
 }
 
-interface HSBColor {
+declare class HSBColor {
     /**
      * The brightness value.
      */
@@ -3548,7 +3548,7 @@ interface HSBColor {
 
 }
 
-interface IndexedConversionOptions {
+declare class IndexedConversionOptions {
     /**
      * The number of palette colors. Valid only when palette =
      * Palette.LOCALADAPTIVE, LOCALPERCEPTUAL, LOCALSELECTIVE, MACOSPALETTE,
@@ -3602,7 +3602,7 @@ interface IndexedConversionOptions {
 
 }
 
-interface JPEGSaveOptions {
+declare class JPEGSaveOptions {
     /**
      * True to embed the color profile in the document.
      */
@@ -3640,7 +3640,7 @@ interface JPEGSaveOptions {
 
 }
 
-interface LabColor {
+declare class LabColor {
     /**
      * The a-value.
      */
@@ -3973,7 +3973,7 @@ interface MeasurementScale {
 
 }
 
-interface NoColor {
+declare class NoColor {
     /**
      * The class name of the referenced noColor object.
      */
@@ -4203,7 +4203,7 @@ interface PathPoint {
 
 }
 
-interface PathPointInfo {
+declare class PathPointInfo {
     /**
      * The X and Y coordinates of the anchor point of the curve.
      */
@@ -4255,7 +4255,7 @@ interface PathPoints {
 
 }
 
-interface PDFOpenOptions {
+declare class PDFOpenOptions {
     /**
      * True to use antialias.
      */
@@ -4313,7 +4313,7 @@ interface PDFOpenOptions {
 
 }
 
-interface PDFSaveOptions {
+declare class PDFSaveOptions {
     /**
      * True to save the alpha channels with the file.
      */
@@ -4465,7 +4465,7 @@ interface PDFSaveOptions {
 
 }
 
-interface PhotoCDOpenOptions {
+declare class PhotoCDOpenOptions {
     /**
      * The profile to use when reading the image.
      */
@@ -4498,7 +4498,7 @@ interface PhotoCDOpenOptions {
 
 }
 
-interface PhotoshopSaveOptions {
+declare class PhotoshopSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4531,7 +4531,7 @@ interface PhotoshopSaveOptions {
 
 }
 
-interface PICTFileSaveOptions {
+declare class PICTFileSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4559,7 +4559,7 @@ interface PICTFileSaveOptions {
 
 }
 
-interface PICTResourceSaveOptions {
+declare class PICTResourceSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4597,7 +4597,7 @@ interface PICTResourceSaveOptions {
 
 }
 
-interface PicturePackageOptions {
+declare class PicturePackageOptions {
     /**
      * The content information (default: PicturePackageTextType.NONE).
      */
@@ -4669,7 +4669,7 @@ interface PicturePackageOptions {
 
 }
 
-interface PixarSaveOptions {
+declare class PixarSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4682,7 +4682,7 @@ interface PixarSaveOptions {
 
 }
 
-interface PNGSaveOptions {
+declare class PNGSaveOptions {
     /**
      * The compression value (default: 0).
      */
@@ -4990,7 +4990,7 @@ interface Preferences {
 
 }
 
-interface PresentationOptions {
+declare class PresentationOptions {
     /**
      * True to auto advance images when when viewing the presentation (default:
      * true). Valid only when presentation = true.
@@ -5043,7 +5043,7 @@ interface PresentationOptions {
 
 }
 
-interface RawFormatOpenOptions {
+declare class RawFormatOpenOptions {
     /**
      * The number of bits for each channel. The only valid values are
      * BitsPerChannelType.EIGHT or BitsPerChannelType.SIXTEEN.
@@ -5098,7 +5098,7 @@ interface RawFormatOpenOptions {
 
 }
 
-interface RawSaveOptions {
+declare class RawSaveOptions {
     /**
      * True if alpha channels should be saved.
      */
@@ -5116,7 +5116,7 @@ interface RawSaveOptions {
 
 }
 
-interface RGBColor {
+declare class RGBColor {
     /**
      * The blue color value (default: 255).
      */
@@ -5302,7 +5302,7 @@ interface Selection {
 
 }
 
-interface SGIRGBSaveOptions {
+declare class SGIRGBSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -5320,7 +5320,7 @@ interface SGIRGBSaveOptions {
 
 }
 
-interface SolidColor {
+declare class SolidColor {
     /**
      * The CMYK color mode.
      */
@@ -5368,7 +5368,7 @@ interface SolidColor {
 
 }
 
-interface SubPathInfo {
+declare class SubPathInfo {
     /**
      * True if the path describes an enclosed area.
      */
@@ -5440,7 +5440,7 @@ interface SubPathItems {
 
 }
 
-interface TargaSaveOptions {
+declare class TargaSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -5897,7 +5897,7 @@ interface TextItem {
 
 }
 
-interface TiffSaveOptions {
+declare class TiffSaveOptions {
     /**
      * True to save the alpha channels.
      */

--- a/dist/cc/ps.types.d.ts
+++ b/dist/cc/ps.types.d.ts
@@ -533,10 +533,14 @@ interface Application {
     readonly locale: string
 
     /**
-     * A list of file image types Adobe Photoshop CC can open. measurementLog
-     * MeasurementLog The log of measurements taken.
+     * A list of file image types Adobe Photoshop CC can open.
      */
     readonly macintoshFileTypes: string[]
+
+    /**
+     * The log of measurements taken.
+     */
+    readonly measurementLog: MeasurementLog
 
     /**
      * The application's name.
@@ -4169,7 +4173,7 @@ interface PathPoint {
     /**
      * The X and Y coordinates of the anchor point of the curve.
      */
-    readonly anchor: number[]
+    readonly anchor: number[][]
 
     /**
      * The role (corner or smooth) this point plays in the containing path
@@ -4203,7 +4207,7 @@ interface PathPointInfo {
     /**
      * The X and Y coordinates of the anchor point of the curve.
      */
-    anchor: number[]
+    anchor: number[][]
 
     /**
      * The role (corner or smooth) this point plays in the containing path
@@ -5251,7 +5255,7 @@ interface Selection {
      * Selects the specified region. The region parameter is an array of four
      * coordinates, [left, top, right, bottom].
      */
-    select(region: number[], type?: SelectionType, feather?: number, antiAlias?: boolean): void
+    select(region: number[][], type?: SelectionType, feather?: number, antiAlias?: boolean): void
 
     /**
      * Selects the entire layer.

--- a/dist/cs6/es.unitvalue.d.ts
+++ b/dist/cs6/es.unitvalue.d.ts
@@ -4,12 +4,12 @@
 */
 interface UnitValue {
 	/**
-     * A UnitValue object that defines the size of one pixel, or a total size to 
+	* A UnitValue object that defines the size of one pixel, or a total size to 
 	 * use as a base for percentage values. This is used as the base conversion 
 	 * unit for pixels and percentages; see Converting pixel and percentage values.
 	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
 	 * pixels at 72 dpi. Set to null to restore the default.
-     */
+	 */
 	baseUnit: UnitValue | null;
 
 	/**
@@ -38,43 +38,43 @@ interface UnitValue {
 
 declare const UnitValue: {
 	/**
-     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * A UnitValue object that defines the size of one pixel, or a total size to 
 	 * use as a base for percentage values. This is used as the base conversion 
 	 * unit for pixels and percentages; see Converting pixel and percentage values.
 	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
 	 * pixels at 72 dpi. Set to null to restore the default.
-     */
+	 */
 	baseUnit: UnitValue | null;
 	
 	/**
-     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * Represents measurement values that contain both the numeric magnitude and the unit 
 	 * of measurement.The UnitValue constructor creates a new UnitValue object.
-     */
+	 */
 	new (value: number | string, unit?: ScaleUnit): UnitValue & number
 	
 	/**
-     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * Represents measurement values that contain both the numeric magnitude and the unit 
 	 * of measurement.The UnitValue constructor creates a new UnitValue object. 
 	 * The keyword new is optional.
-     */
+	 */
 	(value: number | string, unit?: ScaleUnit): UnitValue & number
 }
 
 /**
  * The unit is specified with a string in abbreviated, singular, or plural form.
  */
-type ScaleUnit =  "in" | "inch" | "inches"
-				| "ft" | "foot" | "feet"
-				| "yd" | "yard" | "yards"
-				| "mi" | "mile" | "miles"
-				| "mm" | "millimeter" | "millimeters"
-				| "cm" | "centimeter" | "centimeters"
-				| "m" | "meter" | "meters"
-				| "km" | "kilometer" | "kilometers"
-				| "pt" | "point" | "points"
-				| "pc" | "pica" | "picas"
-				| "tpt" | "traditional point" | "traditional points"
-				| "tpc" | "traditional pica" | "traditional picas"
-				| "ci" | "cicero" | "ciceros"
-				| "px" | "pixel" | "pixels"
-				| "%" | "percent" | "percent"
+type ScaleUnit = "in" | "inch" | "inches"
+		| "ft" | "foot" | "feet"
+		| "yd" | "yard" | "yards"
+		| "mi" | "mile" | "miles"
+		| "mm" | "millimeter" | "millimeters"
+		| "cm" | "centimeter" | "centimeters"
+		| "m" | "meter" | "meters"
+		| "km" | "kilometer" | "kilometers"
+		| "pt" | "point" | "points"
+		| "pc" | "pica" | "picas"
+		| "tpt" | "traditional point" | "traditional points"
+		| "tpc" | "traditional pica" | "traditional picas"
+		| "ci" | "cicero" | "ciceros"
+		| "px" | "pixel" | "pixels"
+		| "%" | "percent" | "percent"

--- a/dist/cs6/ps.types.d.ts
+++ b/dist/cs6/ps.types.d.ts
@@ -6,7 +6,7 @@
 
 /// <reference path="ps.constants.d.ts" />
 
-interface ActionDescriptor {
+declare class ActionDescriptor {
     /**
      * The number of keys contained in the descriptor.
      */
@@ -205,7 +205,7 @@ interface ActionDescriptor {
 
 }
 
-interface ActionList {
+declare class ActionList {
     /**
      * The number of commands that comprise the action.
      */
@@ -373,7 +373,7 @@ interface ActionList {
 
 }
 
-interface ActionReference {
+declare class ActionReference {
     /**
      * The class name of the referenced Action object.
      */
@@ -1359,7 +1359,7 @@ interface ArtLayers {
 
 }
 
-interface BatchOptions {
+declare class BatchOptions {
     /**
      * The type of destination for the processed files (default:
      * BatchDestinationType.NODESTINATION).
@@ -1437,7 +1437,7 @@ interface BatchOptions {
 
 }
 
-interface BitmapConversionOptions {
+declare class BitmapConversionOptions {
     /**
      * The angle (in degrees) at which to orient individual dots. See shape.
      * Valid only when method = BitmapConversionType.HALFTONESCREEN.
@@ -1483,7 +1483,7 @@ interface BitmapConversionOptions {
 
 }
 
-interface BMPSaveOptions {
+declare class BMPSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -1518,7 +1518,7 @@ interface BMPSaveOptions {
 
 }
 
-interface CameraRAWOpenOptions {
+declare class CameraRAWOpenOptions {
     /**
      * The number of bits per channel.
      */
@@ -1758,7 +1758,7 @@ interface Channels {
 
 }
 
-interface CMYKColor {
+declare class CMYKColor {
     /**
      * The black color value (as percent).
      */
@@ -1852,7 +1852,7 @@ interface ColorSamplers {
 
 }
 
-interface ContactSheetOptions {
+declare class ContactSheetOptions {
     /**
      * True to place the images horizontally (left to right, then top to
      * bottom) first (default: true).
@@ -1995,7 +1995,7 @@ interface CountItems {
 
 }
 
-interface DCS1_SaveOptions {
+declare class DCS1_SaveOptions {
     /**
      * (default: DCSType.COLORCOMPOSITE).
      */
@@ -2045,7 +2045,7 @@ interface DCS1_SaveOptions {
 
 }
 
-interface DCS2_SaveOptions {
+declare class DCS2_SaveOptions {
     /**
      * The type of composite file to create (default: DCSType.NOCOMPOSITE).
      */
@@ -2106,7 +2106,7 @@ interface DCS2_SaveOptions {
 
 }
 
-interface DICOMOpenOptions {
+declare class DICOMOpenOptions {
     /**
      * True to make the patient information anonymous.
      */
@@ -2513,7 +2513,7 @@ interface Document {
 
 }
 
-interface DocumentPrintSettings {
+declare class DocumentPrintSettings {
     /**
      * Background color of page.
      */
@@ -2805,7 +2805,7 @@ interface Documents {
 
 }
 
-interface EPSOpenOptions {
+declare class EPSOpenOptions {
     /**
      * True to use antialias.
      */
@@ -2843,7 +2843,7 @@ interface EPSOpenOptions {
 
 }
 
-interface EPSSaveOptions {
+declare class EPSSaveOptions {
     /**
      * True to embed the color profile in this document.
      */
@@ -2899,7 +2899,7 @@ interface EPSSaveOptions {
 
 }
 
-interface ExportOptionsIllustrator {
+declare class ExportOptionsIllustrator {
     /**
      * The type of path to export (default: IllustratorPathType.DOCUMENTBOUNDS).
      */
@@ -2918,7 +2918,7 @@ interface ExportOptionsIllustrator {
 
 }
 
-interface ExportOptionsSaveForWeb {
+declare class ExportOptionsSaveForWeb {
     /**
      * Applies blur to the image to reduce artifacts (default: 0.0).
      */
@@ -3024,7 +3024,7 @@ interface ExportOptionsSaveForWeb {
 
 }
 
-interface GalleryBannerOptions {
+declare class GalleryBannerOptions {
     /**
      * The web photo gallery contact info.
      */
@@ -3062,7 +3062,7 @@ interface GalleryBannerOptions {
 
 }
 
-interface GalleryCustomColorOptions {
+declare class GalleryCustomColorOptions {
     /**
      * The color to use to indicate an active link.
      */
@@ -3100,7 +3100,7 @@ interface GalleryCustomColorOptions {
 
 }
 
-interface GalleryImagesOptions {
+declare class GalleryImagesOptions {
     /**
      * The size (in pixels) of the border that separates images (default: 0).
      */
@@ -3181,7 +3181,7 @@ interface GalleryImagesOptions {
 
 }
 
-interface GalleryOptions {
+declare class GalleryOptions {
     /**
      * True to add width and height attributes for images (default: true).
      */
@@ -3252,7 +3252,7 @@ interface GalleryOptions {
 
 }
 
-interface GallerySecurityOptions {
+declare class GallerySecurityOptions {
     /**
      * The web photo gallery security content (default:
      * GallerySecurityType.NONE).
@@ -3303,7 +3303,7 @@ interface GallerySecurityOptions {
 
 }
 
-interface GalleryThumbnailOptions {
+declare class GalleryThumbnailOptions {
     /**
      * The amount of border pixels you want around your thumbnail images
      * (default: 0).
@@ -3372,7 +3372,7 @@ interface GalleryThumbnailOptions {
 
 }
 
-interface GIFSaveOptions {
+declare class GIFSaveOptions {
     /**
      * The number of palette colors. Valid only when palette =
      * Palette.LOCALADAPTIVE, LOCALPERCEPTUAL, LOCALSELECTIVE, MACOSPALETTE,
@@ -3432,7 +3432,7 @@ interface GIFSaveOptions {
 
 }
 
-interface GrayColor {
+declare class GrayColor {
     /**
      * The gray value (default: 0.0).
      */
@@ -3445,7 +3445,7 @@ interface GrayColor {
 
 }
 
-interface Guide {
+declare class Guide {
     /**
      * Indicates whether the guide is vertical or horizontal.
      */
@@ -3533,7 +3533,7 @@ interface HistoryStates {
 
 }
 
-interface HSBColor {
+declare class HSBColor {
     /**
      * The brightness value.
      */
@@ -3556,7 +3556,7 @@ interface HSBColor {
 
 }
 
-interface IndexedConversionOptions {
+declare class IndexedConversionOptions {
     /**
      * The number of palette colors. Valid only when palette =
      * Palette.LOCALADAPTIVE, LOCALPERCEPTUAL, LOCALSELECTIVE, MACOSPALETTE,
@@ -3610,7 +3610,7 @@ interface IndexedConversionOptions {
 
 }
 
-interface JPEGSaveOptions {
+declare class JPEGSaveOptions {
     /**
      * True to embed the color profile in the document.
      */
@@ -3648,7 +3648,7 @@ interface JPEGSaveOptions {
 
 }
 
-interface LabColor {
+declare class LabColor {
     /**
      * The a-value.
      */
@@ -3981,7 +3981,7 @@ interface MeasurementScale {
 
 }
 
-interface NoColor {
+declare class NoColor {
     /**
      * The class name of the referenced noColor object.
      */
@@ -4211,7 +4211,7 @@ interface PathPoint {
 
 }
 
-interface PathPointInfo {
+declare class PathPointInfo {
     /**
      * The X and Y coordinates of the anchor point of the curve.
      */
@@ -4263,7 +4263,7 @@ interface PathPoints {
 
 }
 
-interface PDFOpenOptions {
+declare class PDFOpenOptions {
     /**
      * True to use antialias.
      */
@@ -4321,7 +4321,7 @@ interface PDFOpenOptions {
 
 }
 
-interface PDFSaveOptions {
+declare class PDFSaveOptions {
     /**
      * True to save the alpha channels with the file.
      */
@@ -4473,7 +4473,7 @@ interface PDFSaveOptions {
 
 }
 
-interface PhotoCDOpenOptions {
+declare class PhotoCDOpenOptions {
     /**
      * The profile to use when reading the image.
      */
@@ -4506,7 +4506,7 @@ interface PhotoCDOpenOptions {
 
 }
 
-interface PhotoshopSaveOptions {
+declare class PhotoshopSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4539,7 +4539,7 @@ interface PhotoshopSaveOptions {
 
 }
 
-interface PICTFileSaveOptions {
+declare class PICTFileSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4567,7 +4567,7 @@ interface PICTFileSaveOptions {
 
 }
 
-interface PICTResourceSaveOptions {
+declare class PICTResourceSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4605,7 +4605,7 @@ interface PICTResourceSaveOptions {
 
 }
 
-interface PicturePackageOptions {
+declare class PicturePackageOptions {
     /**
      * The content information (default: PicturePackageTextType.NONE).
      */
@@ -4677,7 +4677,7 @@ interface PicturePackageOptions {
 
 }
 
-interface PixarSaveOptions {
+declare class PixarSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -4690,7 +4690,7 @@ interface PixarSaveOptions {
 
 }
 
-interface PNGSaveOptions {
+declare class PNGSaveOptions {
     /**
      * The compression value (default: 0).
      */
@@ -4998,7 +4998,7 @@ interface Preferences {
 
 }
 
-interface PresentationOptions {
+declare class PresentationOptions {
     /**
      * True to auto advance images when when viewing the presentation (default:
      * true). Valid only when presentation = true.
@@ -5051,7 +5051,7 @@ interface PresentationOptions {
 
 }
 
-interface RawFormatOpenOptions {
+declare class RawFormatOpenOptions {
     /**
      * The number of bits for each channel. The only valid values are
      * BitsPerChannelType.EIGHT or BitsPerChannelType.SIXTEEN.
@@ -5106,7 +5106,7 @@ interface RawFormatOpenOptions {
 
 }
 
-interface RawSaveOptions {
+declare class RawSaveOptions {
     /**
      * True if alpha channels should be saved.
      */
@@ -5124,7 +5124,7 @@ interface RawSaveOptions {
 
 }
 
-interface RGBColor {
+declare class RGBColor {
     /**
      * The blue color value (default: 255).
      */
@@ -5310,7 +5310,7 @@ interface Selection {
 
 }
 
-interface SGIRGBSaveOptions {
+declare class SGIRGBSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -5328,7 +5328,7 @@ interface SGIRGBSaveOptions {
 
 }
 
-interface SolidColor {
+declare class SolidColor {
     /**
      * The CMYK color mode.
      */
@@ -5376,7 +5376,7 @@ interface SolidColor {
 
 }
 
-interface SubPathInfo {
+declare class SubPathInfo {
     /**
      * True if the path describes an enclosed area.
      */
@@ -5448,7 +5448,7 @@ interface SubPathItems {
 
 }
 
-interface TargaSaveOptions {
+declare class TargaSaveOptions {
     /**
      * True to save the alpha channels.
      */
@@ -5905,7 +5905,7 @@ interface TextItem {
 
 }
 
-interface TiffSaveOptions {
+declare class TiffSaveOptions {
     /**
      * True to save the alpha channels.
      */

--- a/dist/cs6/ps.types.d.ts
+++ b/dist/cs6/ps.types.d.ts
@@ -533,10 +533,14 @@ interface Application {
     readonly locale: string
 
     /**
-     * A list of file image types Adobe Photoshop CS6 can open. measurementLog
-     * MeasurementLog The log of measurements taken.
+     * A list of file image types Adobe Photoshop CS6 can open.
      */
     readonly macintoshFileTypes: string[]
+
+    /**
+     * The log of measurements taken.
+     */
+    readonly measurementLog: MeasurementLog
 
     /**
      * The application's name.
@@ -4177,7 +4181,7 @@ interface PathPoint {
     /**
      * The X and Y coordinates of the anchor point of the curve.
      */
-    readonly anchor: number[]
+    readonly anchor: number[][]
 
     /**
      * The role (corner or smooth) this point plays in the containing path
@@ -4211,7 +4215,7 @@ interface PathPointInfo {
     /**
      * The X and Y coordinates of the anchor point of the curve.
      */
-    anchor: number[]
+    anchor: number[][]
 
     /**
      * The role (corner or smooth) this point plays in the containing path
@@ -5259,7 +5263,7 @@ interface Selection {
      * Selects the specified region. The region parameter is an array of four
      * coordinates, [left, top, right, bottom].
      */
-    select(region: number[], type?: SelectionType, feather?: number, antiAlias?: boolean): void
+    select(region: number[][], type?: SelectionType, feather?: number, antiAlias?: boolean): void
 
     /**
      * Selects the entire layer.

--- a/extendscript/es.unitvalue.d.ts
+++ b/extendscript/es.unitvalue.d.ts
@@ -4,12 +4,12 @@
 */
 interface UnitValue {
 	/**
-     * A UnitValue object that defines the size of one pixel, or a total size to 
+	* A UnitValue object that defines the size of one pixel, or a total size to 
 	 * use as a base for percentage values. This is used as the base conversion 
 	 * unit for pixels and percentages; see Converting pixel and percentage values.
 	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
 	 * pixels at 72 dpi. Set to null to restore the default.
-     */
+	 */
 	baseUnit: UnitValue | null;
 
 	/**
@@ -38,43 +38,43 @@ interface UnitValue {
 
 declare const UnitValue: {
 	/**
-     * A UnitValue object that defines the size of one pixel, or a total size to 
+	 * A UnitValue object that defines the size of one pixel, or a total size to 
 	 * use as a base for percentage values. This is used as the base conversion 
 	 * unit for pixels and percentages; see Converting pixel and percentage values.
 	 * Default is 0.013889 inches (1/72 in), which is the base conversion unit for
 	 * pixels at 72 dpi. Set to null to restore the default.
-     */
+	 */
 	baseUnit: UnitValue | null;
 	
 	/**
-     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * Represents measurement values that contain both the numeric magnitude and the unit 
 	 * of measurement.The UnitValue constructor creates a new UnitValue object.
-     */
+	 */
 	new (value: number | string, unit?: ScaleUnit): UnitValue & number
 	
 	/**
-     * Represents measurement values that contain both the numeric magnitude and the unit 
+	 * Represents measurement values that contain both the numeric magnitude and the unit 
 	 * of measurement.The UnitValue constructor creates a new UnitValue object. 
 	 * The keyword new is optional.
-     */
+	 */
 	(value: number | string, unit?: ScaleUnit): UnitValue & number
 }
 
 /**
  * The unit is specified with a string in abbreviated, singular, or plural form.
  */
-type ScaleUnit =  "in" | "inch" | "inches"
-				| "ft" | "foot" | "feet"
-				| "yd" | "yard" | "yards"
-				| "mi" | "mile" | "miles"
-				| "mm" | "millimeter" | "millimeters"
-				| "cm" | "centimeter" | "centimeters"
-				| "m" | "meter" | "meters"
-				| "km" | "kilometer" | "kilometers"
-				| "pt" | "point" | "points"
-				| "pc" | "pica" | "picas"
-				| "tpt" | "traditional point" | "traditional points"
-				| "tpc" | "traditional pica" | "traditional picas"
-				| "ci" | "cicero" | "ciceros"
-				| "px" | "pixel" | "pixels"
-				| "%" | "percent" | "percent"
+type ScaleUnit = "in" | "inch" | "inches"
+		| "ft" | "foot" | "feet"
+		| "yd" | "yard" | "yards"
+		| "mi" | "mile" | "miles"
+		| "mm" | "millimeter" | "millimeters"
+		| "cm" | "centimeter" | "centimeters"
+		| "m" | "meter" | "meters"
+		| "km" | "kilometer" | "kilometers"
+		| "pt" | "point" | "points"
+		| "pc" | "pica" | "picas"
+		| "tpt" | "traditional point" | "traditional points"
+		| "tpc" | "traditional pica" | "traditional picas"
+		| "ci" | "cicero" | "ciceros"
+		| "px" | "pixel" | "pixels"
+		| "%" | "percent" | "percent"

--- a/renderers/types.ts
+++ b/renderers/types.ts
@@ -77,7 +77,7 @@ const renderProperty = (property, indentLevel = 0) =>
           '${perms}${name}: ${type}'
         , { name: property.name
           , type: property.type.name
-          , perms: (property.perms == 'Read-only') ? 'readonly ': ''
+          , perms: (property.perms == 'Read-only') ? 'readonly ' : ''
           }
       )))
         .map(x => strRepeat(' ', tabSize*indentLevel) + x)
@@ -87,7 +87,17 @@ const renderProperty = (property, indentLevel = 0) =>
 
 const renderType = type =>
     _.flatten(
-    [ _.template('interface ${name} {', { name: type.name })
+    [ _.template(
+        '${declaration} ${name} {'
+        , { declaration: 
+            type.props.some(function(property) {return (property.name == 'parent')}) 
+            || (type.name == "Application")
+            || (type.name == "UnitValue")
+            || (type.name.indexOf("Measurement") !== -1) 
+            ? 'interface' : 'declare class'
+          , name: type.name
+        }
+    )
     , _.map(type.props,   m => renderProperty(m, 1) + '\n')
     , _.map(type.methods, m => renderMethod(m, 1)   + '\n')
     , '}'


### PR DESCRIPTION
Half of the PS objects/functions are DOM objects and perfectly declared as interfaces, while the other half actually are used like classes and can be instantiated.

DOM objects can be filtered on their "parent" property. Just "MeasurementLog" and "MeasurementScale" do not have this property for some reason. "Application" and "UnitValue" are special cases anyway. These exceptions are respected in the renderer (kind of hardcoded...). Let me know what you think about it.

The other part of functions will now be declared as classes. They do not have explicit parameters in their constructors (nor are they documented), but Extendscript wants them to be specified like this:

```javascript
var myColor = new SolidColor()
myColor.rgb.blue = 50
myColor.rgb.green = 40
myColor.rgb.red = 90
```

There's a separate file in the assets now that documents what's a DOM object or a class for any possible future use.

Finally a minor fix in the assets about arrays of 2D point coordinates (should be number[][], documentation says just number[]). Example: 

```typescript
let A = [0, 0];
let B = [50, 0];
let C = [50, 50];
let D = [0, 50];
let square = [A, B, C, D];
app.activeDocument.selection.select(square);
```