### PR TITLE
Fix $.level and Document.exportDocument parameter

### DIFF
--- a/assets/cc/chapter-2.txt
+++ b/assets/cc/chapter-2.txt
@@ -2086,9 +2086,7 @@ exportDocument
 [, options])
 File
 ExportType
-ExportOptionsIllustrator
-—or—
-ExportOptionsSaveForWeb
+ExportOptionsIllustrator|ExportOptionsSaveForWeb
 Exports the paths in the document to an
 Illustrator file, or exports the document to
 a file with Web or device viewing

--- a/assets/cs6/chapter-2.txt
+++ b/assets/cs6/chapter-2.txt
@@ -2145,9 +2145,7 @@ exportDocument
 [, options])
 File
 ExportType
-ExportOptionsIllustrator
-—or—
-ExportOptionsSaveForWeb
+ExportOptionsIllustrator|ExportOptionsSaveForWeb
 Exports the paths in the document to an
 Illustrator file, or exports the document to
 a file with Web or device viewing

--- a/dist/cc/es.dollar.d.ts
+++ b/dist/cc/es.dollar.d.ts
@@ -85,12 +85,12 @@ declare class $ {
 
     /**
      * The current debugging level, which enables or disables the JavaScript
-     * debugger. Read only. One of:
+     * debugger. One of:
      * 0: No debugging
      * 1: Break on runtime errors
      * 2: Full debug mode
      */
-    static readonly level: number
+    static level: number
 
     /**
      * The current line of the currently executing script; the first line is
@@ -231,7 +231,7 @@ declare class $ {
      * @param text One or more strings to write, which are concatenated to form
      * a single string.
      */
-    static write(text: any,  ...texts: any[]): void
+    static write(text: any, ...texts: any[]): void
 
     /**
      * Writes the specified text to the JavaScript Console and appends a
@@ -240,5 +240,5 @@ declare class $ {
      * @param text One or more strings to write, which are concatenated to form
      * a single string.
      */
-    static writeln(text: any,  ...texts: any[]): void
+    static writeln(text: any, ...texts: any[]): void
 }

--- a/dist/cc/ps.types.d.ts
+++ b/dist/cc/ps.types.d.ts
@@ -2382,12 +2382,12 @@ interface Document {
     duplicate(name?: string, mergeLayersOnly?: boolean): Document
 
     /**
-     * —or— ExportOptionsSaveForWeb Exports the paths in the document to an
-     * Illustrator file, or exports the document to a file with Web or device
-     * viewing optimizations. This is equivalent to choosing File > Export >
-     * Paths To Illustrator, or File > Save For Web and Devices.
+     * Exports the paths in the document to an Illustrator file, or exports the
+     * document to a file with Web or device viewing optimizations. This is
+     * equivalent to choosing File > Export > Paths To Illustrator, or File >
+     * Save For Web and Devices.
      */
-    exportDocument(exportIn: File, exportAs?: ExportType, options?: ExportOptionsIllustrator): void
+    exportDocument(exportIn: File, exportAs?: ExportType, options?: ExportOptionsIllustrator|ExportOptionsSaveForWeb): void
 
     /**
      * Flattens all layers in the document.

--- a/dist/cs6/es.dollar.d.ts
+++ b/dist/cs6/es.dollar.d.ts
@@ -85,12 +85,12 @@ declare class $ {
 
     /**
      * The current debugging level, which enables or disables the JavaScript
-     * debugger. Read only. One of:
+     * debugger. One of:
      * 0: No debugging
      * 1: Break on runtime errors
      * 2: Full debug mode
      */
-    static readonly level: number
+    static level: number
 
     /**
      * The current line of the currently executing script; the first line is
@@ -231,7 +231,7 @@ declare class $ {
      * @param text One or more strings to write, which are concatenated to form
      * a single string.
      */
-    static write(text: any,  ...texts: any[]): void
+    static write(text: any, ...texts: any[]): void
 
     /**
      * Writes the specified text to the JavaScript Console and appends a
@@ -240,5 +240,5 @@ declare class $ {
      * @param text One or more strings to write, which are concatenated to form
      * a single string.
      */
-    static writeln(text: any,  ...texts: any[]): void
+    static writeln(text: any, ...texts: any[]): void
 }

--- a/dist/cs6/ps.types.d.ts
+++ b/dist/cs6/ps.types.d.ts
@@ -2391,12 +2391,12 @@ interface Document {
     duplicate(name?: string, mergeLayersOnly?: boolean): Document
 
     /**
-     * —or— ExportOptionsSaveForWeb Exports the paths in the document to an
-     * Illustrator file, or exports the document to a file with Web or device
-     * viewing optimizations. This is equivalent to choosing File > Export >
-     * Paths To Illustrator, or File > Save For Web and Devices.
+     * Exports the paths in the document to an Illustrator file, or exports the
+     * document to a file with Web or device viewing optimizations. This is
+     * equivalent to choosing File > Export > Paths To Illustrator, or File >
+     * Save For Web and Devices.
      */
-    exportDocument(exportIn: File, exportAs?: ExportType, options?: ExportOptionsIllustrator): void
+    exportDocument(exportIn: File, exportAs?: ExportType, options?: ExportOptionsIllustrator|ExportOptionsSaveForWeb): void
 
     /**
      * Flattens all layers in the document.

--- a/extendscript/es.dollar.d.ts
+++ b/extendscript/es.dollar.d.ts
@@ -85,12 +85,12 @@ declare class $ {
 
     /**
      * The current debugging level, which enables or disables the JavaScript
-     * debugger. Read only. One of:
+     * debugger. One of:
      * 0: No debugging
      * 1: Break on runtime errors
      * 2: Full debug mode
      */
-    static readonly level: number
+    static level: number
 
     /**
      * The current line of the currently executing script; the first line is
@@ -231,7 +231,7 @@ declare class $ {
      * @param text One or more strings to write, which are concatenated to form
      * a single string.
      */
-    static write(text: any,  ...texts: any[]): void
+    static write(text: any, ...texts: any[]): void
 
     /**
      * Writes the specified text to the JavaScript Console and appends a
@@ -240,5 +240,5 @@ declare class $ {
      * @param text One or more strings to write, which are concatenated to form
      * a single string.
      */
-    static writeln(text: any,  ...texts: any[]): void
+    static writeln(text: any, ...texts: any[]): void
 }

--- a/parsers/types.ts
+++ b/parsers/types.ts
@@ -71,7 +71,7 @@ const typeBlacklist = [ 'Methods', 'File' ];
  */
 const identifier = parse.label('identifier'
     , text.letter.chain(first =>
-        parse.eager(parse.many(text.match(/[a-zA-Z_0-9]/))).chain(rest =>
+        parse.eager(parse.many(text.match(/[a-zA-Z_0-9|]/))).chain(rest =>
             parse.always(first + rest.join(''))
         )
     )


### PR DESCRIPTION
- Remove readonly on $.level. The JavaScript Tools Guide says it's readonly, but it's actually used to set the debug level.
- Fix the option parameter in Document.exportDocument