### PR TITLE
Change return type of prompt from boolean to string

### DIFF
--- a/dist/cc/es.tools.d.ts
+++ b/dist/cc/es.tools.d.ts
@@ -172,7 +172,7 @@ declare function confirm(message: string, noAsDflt?: boolean, title?: string): b
  * Windows, this appears in the window’s frame, while on Mac OS it appears
  * above the message. The default title string is "Script Prompt."
  */
-declare function prompt(message: string, preset: string, title?: string): boolean
+declare function prompt(message: string, preset: string, title?: string): string
 
 
 //*** UnitValue ***//

--- a/dist/cs6/es.tools.d.ts
+++ b/dist/cs6/es.tools.d.ts
@@ -172,7 +172,7 @@ declare function confirm(message: string, noAsDflt?: boolean, title?: string): b
  * Windows, this appears in the window’s frame, while on Mac OS it appears
  * above the message. The default title string is "Script Prompt."
  */
-declare function prompt(message: string, preset: string, title?: string): boolean
+declare function prompt(message: string, preset: string, title?: string): string
 
 
 //*** UnitValue ***//

--- a/extendscript/es.tools.d.ts
+++ b/extendscript/es.tools.d.ts
@@ -172,7 +172,7 @@ declare function confirm(message: string, noAsDflt?: boolean, title?: string): b
  * Windows, this appears in the window’s frame, while on Mac OS it appears
  * above the message. The default title string is "Script Prompt."
  */
-declare function prompt(message: string, preset: string, title?: string): boolean
+declare function prompt(message: string, preset: string, title?: string): string
 
 
 //*** UnitValue ***//


### PR DESCRIPTION
Change return type of `prompt` from `boolean` to `string`

`confirm` is the method that returns a `boolean` (as it is correctly declared a few lines earlier)

Thanks for this package by the way, it makes life a lot easier!